### PR TITLE
Support normalizing attributes even if they are not backed by database columns

### DIFF
--- a/lib/normalize_attributes/active_record.rb
+++ b/lib/normalize_attributes/active_record.rb
@@ -71,7 +71,11 @@ module NormalizeAttributes
           end
         end
 
-        write_attribute name, value
+        begin
+          write_attribute name, value
+        rescue ActiveModel::MissingAttributeError
+          send :"#{name}=", value
+        end
       end
     end
   end

--- a/spec/normalize_attributes_spec.rb
+++ b/spec/normalize_attributes_spec.rb
@@ -109,4 +109,13 @@ describe "Normalize Attributes" do
       user.save
     }.to_not raise_error
   end
+
+  it "should normalize attributes that are not backed by database columns" do
+    User.normalize :nickname, :with => :downcase
+
+    user = User.new(:username => "john@doe.com")
+    user.nickname = "JOHNNY D"
+    expect{user.save}.to_not raise_error
+    expect(user.nickname).to eq("johnny d")
+  end
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -2,6 +2,8 @@ class User < ActiveRecord::Base
   has_many :tokens
   serialize :preferences
 
+  attr_accessor :nickname
+
   def normalize_username(username)
     username.downcase
   end


### PR DESCRIPTION
Our team needed to use this gem to normalize model attributes that were not directly backed by database columns. (Our specific use case involves several attributes handled by the [attr_encrypted](https://github.com/attr-encrypted/attr_encrypted) gem, but any attribute that's set via standard accessor methods should, in principle, be normalizable.)

This PR changes the `apply_normalizers` method so that it will first attempt to use ActiveRecord's `write_attribute` method, but fall back to using a standard setter method if that attempt fails.

A spec was added to test this behavior.