### PR TITLE
Raise an error when normalizer is unknown

### DIFF
--- a/lib/normalize_attributes/callbacks.rb
+++ b/lib/normalize_attributes/callbacks.rb
@@ -35,6 +35,8 @@ module NormalizeAttributes
         value = value.send(normalizer)
       elsif record.respond_to?(normalizer)
         value = record.send(normalizer, value)
+      else
+        raise RuntimeError, "unknown normalizer #{normalizer.inspect} for #{record.inspect}"
       end
     end
 

--- a/test/normalize_attributes_test.rb
+++ b/test/normalize_attributes_test.rb
@@ -98,11 +98,10 @@ class NormalizeAttributesTest < Minitest::Test
     assert_equal "100", user.username
   end
 
-  test "don't apply filter when object do not respond to normalizer" do
+  test "raises an error when object do not respond to normalizer" do
     User.normalize :username, with: :missing
 
-    user = User.create(username: nil)
-    user.save
+    assert_raises(RuntimeError) { User.create(username: nil) }
   end
 
   test "normalize attributes that are not backed by database columns" do


### PR DESCRIPTION
That will help with typos and invalid objects given to the normalize
call.